### PR TITLE
feat: log unknown labels encountered in evaluation

### DIFF
--- a/flair/nn/model.py
+++ b/flair/nn/model.py
@@ -615,6 +615,7 @@ class DefaultClassifier(Classifier[DT], typing.Generic[DT, DT2], ABC):
 
         # initialize the label dictionary
         self.label_dictionary: Dictionary = label_dictionary
+        self.printed_labels = False  # only print labels in warning once
 
         # initialize the decoder
         if decoder is not None:
@@ -862,7 +863,7 @@ class DefaultClassifier(Classifier[DT], typing.Generic[DT, DT2], ABC):
 
             overall_loss = torch.zeros(1, device=flair.device)
             label_count = 0
-            has_any_unknown_label = False
+            unknown_labels = set()
             for batch in batches:
                 # filter data points in batch
                 batch = [dp for dp in batch if self._filter_data_point(dp)]
@@ -890,15 +891,20 @@ class DefaultClassifier(Classifier[DT], typing.Generic[DT, DT2], ABC):
                     if return_loss:
                         # filter data points that have labels outside of dictionary
                         filtered_indices = []
-                        has_unknown_label = False
+                        batch_has_unknown_label = False
                         for idx, dp in enumerate(data_points):
                             if all(self.label_dictionary.has_item(label) for label in self._get_label_of_datapoint(dp)):
                                 filtered_indices.append(idx)
                             else:
-                                has_unknown_label = True
-
-                        if has_unknown_label:
-                            has_any_unknown_label = True
+                                batch_has_unknown_label = True
+                                unknown_labels.update(
+                                    {
+                                        label.value
+                                        for label in dp.get_labels()
+                                        if not self.label_dictionary.has_item(label.value)
+                                    }
+                                )
+                        if batch_has_unknown_label:
                             scores = torch.index_select(
                                 scores, 0, torch.tensor(filtered_indices, device=flair.device, dtype=torch.int32)
                             )
@@ -944,11 +950,13 @@ class DefaultClassifier(Classifier[DT], typing.Generic[DT, DT2], ABC):
                 self._post_process_batch_after_prediction(batch, label_name)
 
             if return_loss:
-                if has_any_unknown_label:
+                if unknown_labels:
                     log.info(
-                        "During evaluation, encountered labels that are not in the label_dictionary:"
-                        "Evaluation loss is computed without them."
+                        f"During evaluation, encountered labels that are not in the label dictionary:\n{data_points_w_unknown_labels}"
                     )
+                    if not self.printed_labels:
+                        log.warning(f"Labels in label dictionary:\n{self.label_dictionary.get_items()}")
+                        self.printed_labels = True
                 return overall_loss, label_count
             return None
 


### PR DESCRIPTION
When unknown labels are encountered during evaluation, you are warned but not told what the labels are, which could help with debugging. I considered making a debug flag to flip this on, but the logs already get cluttered with these messages and they're just not that useful