### PR TITLE
Log regression task metrics in multitask model

### DIFF
--- a/flair/models/multitask_model.py
+++ b/flair/models/multitask_model.py
@@ -198,8 +198,9 @@ class MultitaskModel(flair.nn.Classifier):
             # Add metrics so they will be available to _publish_eval_result.
             for avg_type in ("micro avg", "macro avg"):
                 for metric_type in ("f1-score", "precision", "recall"):
-                    if (result.classification_report.get(avg_type) and 
-                        result.classification_report[avg_type].get(metric_type)):
+                    if result.classification_report.get(avg_type) and result.classification_report[avg_type].get(
+                        metric_type
+                    ):
                         scores[(task_id, avg_type, metric_type)] = result.classification_report[avg_type][metric_type]
 
         scores["loss"] = loss.item() / len(batch_split)

--- a/flair/models/multitask_model.py
+++ b/flair/models/multitask_model.py
@@ -198,7 +198,7 @@ class MultitaskModel(flair.nn.Classifier):
             # Add metrics so they will be available to _publish_eval_result.
             for avg_type in ("micro avg", "macro avg"):
                 for metric_type in ("f1-score", "precision", "recall"):
-                    if result.classification_report.get(avg_type) and result.classification_report["avg_type"].get(metric_type):
+                    if result.classification_report.get(avg_type, None) and result.classification_report["avg_type"].get(metric_type, None):
                         scores[(task_id, avg_type, metric_type)] = result.classification_report[avg_type][metric_type]
 
         scores["loss"] = loss.item() / len(batch_split)

--- a/flair/models/multitask_model.py
+++ b/flair/models/multitask_model.py
@@ -198,7 +198,8 @@ class MultitaskModel(flair.nn.Classifier):
             # Add metrics so they will be available to _publish_eval_result.
             for avg_type in ("micro avg", "macro avg"):
                 for metric_type in ("f1-score", "precision", "recall"):
-                    if result.classification_report.get(avg_type) and result.classification_report[avg_type].get(metric_type):
+                    if (result.classification_report.get(avg_type) and 
+                        result.classification_report[avg_type].get(metric_type)):
                         scores[(task_id, avg_type, metric_type)] = result.classification_report[avg_type][metric_type]
 
         scores["loss"] = loss.item() / len(batch_split)

--- a/flair/models/multitask_model.py
+++ b/flair/models/multitask_model.py
@@ -203,10 +203,11 @@ class MultitaskModel(flair.nn.Classifier):
                     ):
                         scores[(task_id, avg_type, metric_type)] = result.classification_report[avg_type][metric_type]
 
-            # The above metrics only apply to classification tasks. For regression
-            # tasks add mse.
-            if result.scores.get("mse"):
-                scores[(task_id, "mse")] = result.scores["mse"]
+            # The above metrics only apply to classification tasks. This adds
+            # regression metrics also.
+            for metric_type in ("mse", "mae", "pearson", "spearman"):
+                if result.scores.get(metric_type):
+                    scores[(task_id, metric_type)] = result.scores[metric_type]
 
         scores["loss"] = loss.item() / len(batch_split)
 

--- a/flair/models/multitask_model.py
+++ b/flair/models/multitask_model.py
@@ -198,7 +198,8 @@ class MultitaskModel(flair.nn.Classifier):
             # Add metrics so they will be available to _publish_eval_result.
             for avg_type in ("micro avg", "macro avg"):
                 for metric_type in ("f1-score", "precision", "recall"):
-                    scores[(task_id, avg_type, metric_type)] = result.classification_report[avg_type][metric_type]
+                    if result.classification_report.get(avg_type) and result.classification_report["avg_type"].get(metric_type):
+                        scores[(task_id, avg_type, metric_type)] = result.classification_report[avg_type][metric_type]
 
         scores["loss"] = loss.item() / len(batch_split)
 

--- a/flair/models/multitask_model.py
+++ b/flair/models/multitask_model.py
@@ -198,7 +198,7 @@ class MultitaskModel(flair.nn.Classifier):
             # Add metrics so they will be available to _publish_eval_result.
             for avg_type in ("micro avg", "macro avg"):
                 for metric_type in ("f1-score", "precision", "recall"):
-                    if result.classification_report.get(avg_type, None) and result.classification_report["avg_type"].get(metric_type, None):
+                    if result.classification_report.get(avg_type) and result.classification_report[avg_type].get(metric_type):
                         scores[(task_id, avg_type, metric_type)] = result.classification_report[avg_type][metric_type]
 
         scores["loss"] = loss.item() / len(batch_split)

--- a/flair/models/multitask_model.py
+++ b/flair/models/multitask_model.py
@@ -203,6 +203,11 @@ class MultitaskModel(flair.nn.Classifier):
                     ):
                         scores[(task_id, avg_type, metric_type)] = result.classification_report[avg_type][metric_type]
 
+            # The above metrics only apply to classification tasks. For regression
+            # tasks add mse.
+            if result.scores.get("mse"):
+                scores[(task_id, "mse")] = result.scores["mse"]
+
         scores["loss"] = loss.item() / len(batch_split)
 
         return Result(


### PR DESCRIPTION
Recently per-task metrics were added to multitask_model, however we did not include any for regression tasks and we did not check that the metric keys are present which can throw an error, so this addresses both of those concerns.