### PR TITLE
fix dummy result

### DIFF
--- a/flair/models/pairwise_regression_model.py
+++ b/flair/models/pairwise_regression_model.py
@@ -383,7 +383,7 @@ class TextPairRegressor(flair.nn.Model[TextPair], ReduceTransformerVocabMixin):
                 )
 
             else:  # if it's not the main process, just set a dummy Result
-                result = Result(0.0, "", {}, {"loss": 0.0})
+                result = Result(main_score=0.0, detailed_results="", scores={"loss": 0.0}, classification_report={})
 
             if multi_gpu:
                 result = broadcast_value(result, src=0)

--- a/flair/models/text_regression_model.py
+++ b/flair/models/text_regression_model.py
@@ -233,7 +233,7 @@ class TextRegressor(flair.nn.Model[Sentence], ReduceTransformerVocabMixin):
                 )
 
             else:  # if it's not the main process, just set a dummy Result
-                result = Result(0.0, "", {}, {"loss": 0.0})
+                result = Result(main_score=0.0, detailed_results="", scores={"loss": 0.0}, classification_report={})
 
             if multi_gpu:
                 result = broadcast_value(result, src=0)

--- a/flair/nn/model.py
+++ b/flair/nn/model.py
@@ -472,7 +472,7 @@ class Classifier(Model[DT], typing.Generic[DT], ReduceTransformerVocabMixin, ABC
             average_over = aggregate(average_over, sum)
             eval_loss = aggregate(eval_loss, aggregate_tensor_sum)
 
-        result = Result(0.0, "", {}, {"loss": 0.0})
+        result = Result(main_score=0.0, detailed_results="", scores={"loss": 0.0}, classification_report={})
         if is_main_process():
 
             # convert true and predicted values to two span-aligned lists


### PR DESCRIPTION
## Motivation
The `__init__` function of `Result` in flair has changed.
![Screenshot 2025-04-03 at 9 42 50 PM](https://github.com/user-attachments/assets/4d544f96-3107-4bf7-9bb8-538f19111154)
"dummy" results need to changed accordingly.

## Test
I tested by copying this repo to ziprecruiter and running a [flyte execution](https://workflows--flyte.x1-pdx-ue1.zipaws.com/console/projects/resume--pipeline/domains/fast/executions/fb991d2239428409bbad?duration=all) using it.