### PR TITLE
Feat: Store prototype embeddings on CPU optionally

### DIFF
--- a/flair/nn/decoder.py
+++ b/flair/nn/decoder.py
@@ -148,6 +148,7 @@ class DeepNCMDecoder(torch.nn.Module):
         alpha: float = 0.9,
         mean_update_method: Literal["online", "condensation", "decay"] = "online",
         multi_label: bool = False,  # should get from the Model it belongs to
+        store_prototypes_on_cpu: bool = False,
     ) -> None:
         """Initialize a DeepNCMDecoder.
 
@@ -162,6 +163,7 @@ class DeepNCMDecoder(torch.nn.Module):
                 condensation -
                 decay - after every batch,
             multi_label: Whether to predict multiple labels per sentence (default is False, and performs multi-class clsasification).
+            store_prototypes_on_cpu: Whether to store the class prototypes on CPU (default is False, and stores them on the same device as the model).
         """
         super().__init__()
 
@@ -182,7 +184,7 @@ class DeepNCMDecoder(torch.nn.Module):
 
         self.class_prototypes = torch.nn.Parameter(
             torch.nn.functional.normalize(torch.randn(self._num_prototypes, self.encoding_dim)), requires_grad=False
-        ).to('cpu')
+        ).to('cpu' if store_prototypes_on_cpu else flair.device)
 
         self.class_counts = torch.nn.Parameter(torch.zeros(self._num_prototypes), requires_grad=False)
         self.prototype_updates = torch.zeros_like(self.class_prototypes).to(flair.device)


### PR DESCRIPTION
This PR adds an option to `DeepNCMClassifier` to keep prototypes stored on CPU, and only transfers relevant indices to GPU before doing calculations. This prevents GPU RAM usage increasing with large numbers of class prototypes