### PR TITLE
Allow precomputed embeddings in TextPairClassifier

### DIFF
--- a/flair/models/pairwise_classification_model.py
+++ b/flair/models/pairwise_classification_model.py
@@ -74,7 +74,12 @@ class TextPairClassifier(flair.nn.DefaultClassifier[TextPair, TextPair]):
     def _get_embedding_for_data_point(self, prediction_data_point: TextPair) -> torch.Tensor:
         embedding_names = self.embeddings.get_names()
         if self.embed_separately:
-            self.embeddings.embed([prediction_data_point.first, prediction_data_point.second])
+            # Compute embeddings if not already present.
+            if (
+                prediction_data_point.first.embedding.numel() == 0
+                or prediction_data_point.second.embedding.numel() == 0
+            ):
+                self.embeddings.embed([prediction_data_point.first, prediction_data_point.second])
             return torch.cat(
                 [
                     prediction_data_point.first.get_embedding(embedding_names),


### PR DESCRIPTION
For our scoring pipeline, we have one step where we compute embeddings, then another for scoring. That requires being able to pass in the precomputed embeddings (which is enabled by this change).

Here is an example usage:
```
icq_model = TextPairClassifierPrecompute.load(path).to("cuda")
icq_model.decoder.to(torch.bfloat16)

js_sentence = Sentence("unused js sentence")
js_sentence.set_embedding(
    "transformer-Qwen/Qwen2.5-0.5B-Instruct",
    torch.tensor(js_embed).to(torch.bfloat16),
)    
job_sentence = Sentence("unused job sentence")
job_sentence.set_embedding(
    "transformer-Qwen/Qwen2.5-0.5B-Instruct",
    torch.tensor(job_embed).to(torch.bfloat16),
)

input = TextPair(js_sentence, job_sentence)                
icq_model.predict(input)
```